### PR TITLE
initial pass at Recommit reaction (Starforged)

### DIFF
--- a/TheOracle/GameCore/ProgressTracker/ProgressTrackerInfo.cs
+++ b/TheOracle/GameCore/ProgressTracker/ProgressTrackerInfo.cs
@@ -84,6 +84,7 @@ namespace TheOracle.GameCore.ProgressTracker
         {
             return new EmbedBuilder()
                 .WithTitle(ProgressResources.Progress_Tracker)
+                .WithAuthor(ProgressResources.Progress_Tracker)
                 .WithThumbnailUrl(IconUrl)
                 .WithDescription(Description)
                 .WithFields(new EmbedFieldBuilder()
@@ -112,7 +113,6 @@ namespace TheOracle.GameCore.ProgressTracker
         {
             Ticks -= TicksPerProgress;
         }
-
         public void AddProgress(int amount = 1)
         {
             Ticks += TicksPerProgress;


### PR DESCRIPTION
adds Recommit (❤️‍🩹 ) reaction, used by some Starforged Progress Moves on a Miss (Fulfill Your Vow, Finish an Expedition, Forge a Bond).

i'm open to changing the emoji - 🔄 or ♻️ might be reasonable alternatives.

Delve does something like it with its Progress Move, but iirc it's different enough that it's probably best addressed with a unique react on the delve embed.

